### PR TITLE
fix `-v` flag to do something again

### DIFF
--- a/src/vernac/compile.py
+++ b/src/vernac/compile.py
@@ -68,7 +68,11 @@ def main(
 
     stages = [
         ReadSourceStage("Reading source"),
-        GenerateCodeStage("Generating code", inject_first=inject_first),
+        GenerateCodeStage(
+            "Generating code",
+            inject_first=inject_first,
+            verbose=verbose,
+        ),
         GuessDependenciesStage("Guessing dependencies"),
         PackageStage("Packaging", out_path=out_path),
         CheckHelpStage("Checking --help"),

--- a/src/vernac/stages/generate_code.py
+++ b/src/vernac/stages/generate_code.py
@@ -21,9 +21,15 @@ class TestFailure:
 class GenerateCodeStage(VernacStage):
     steps = 100
 
-    def __init__(self, title: str, inject_first: str | None = None):
+    def __init__(
+            self,
+            title: str,
+            inject_first: str | None = None,
+            verbose: bool = False,
+        ):
         self.title = title
         self.inject_first = inject_first
+        self.verbose = verbose
 
     def run(
             self,
@@ -93,6 +99,9 @@ class GenerateCodeStage(VernacStage):
         context.log_text("completion.txt", chat_completion)
 
         python = strip_markdown_fence(chat_completion)
+
+        if self.verbose:
+            print(python)
 
         context.log_text("code.py", python)
 


### PR DESCRIPTION
It could do more, but at least it does something (prints generated code).